### PR TITLE
issue/12-passcode-preference-npe-actionbar

### DIFF
--- a/library/src/org/wordpress/passcodelock/PasscodePreferencesActivity.java
+++ b/library/src/org/wordpress/passcodelock/PasscodePreferencesActivity.java
@@ -27,7 +27,7 @@ public class PasscodePreferencesActivity extends PreferenceActivity {
 
         setTitle(getResources().getText(R.string.passcode_manage));
 
-        if (android.os.Build.VERSION.SDK_INT >= 11) {
+        if (android.os.Build.VERSION.SDK_INT >= 11 && getActionBar() != null) {
             getActionBar().setDisplayHomeAsUpEnabled(true);
         }
                 


### PR DESCRIPTION
Fix #12 - Added getActionBar() null check to PasscodePreferenceActivity
