### PR TITLE
Do not open new keyboard when Pin lock screen field gets the focus

### DIFF
--- a/library/res/layout/app_passcode_keyboard.xml
+++ b/library/res/layout/app_passcode_keyboard.xml
@@ -48,6 +48,8 @@
             android:layout_height="wrap_content"
             android:layout_marginRight="38dp"
             android:hint="@string/passcodelock_hint"
+            android:focusable="false"
+            android:clickable="false"
             android:maxLength="4"
             android:inputType="numberPassword"
             android:background="@color/white" />

--- a/library/src/org/wordpress/passcodelock/AbstractPasscodeKeyboardActivity.java
+++ b/library/src/org/wordpress/passcodelock/AbstractPasscodeKeyboardActivity.java
@@ -6,6 +6,7 @@ import android.os.Bundle;
 import android.support.v4.hardware.fingerprint.FingerprintManagerCompat;
 import android.support.v4.os.CancellationSignal;
 import android.text.InputFilter;
+import android.text.InputType;
 import android.text.Spanned;
 import android.view.Gravity;
 import android.view.View;
@@ -51,6 +52,7 @@ public abstract class AbstractPasscodeKeyboardActivity extends Activity {
         filters[1] = onlyNumber;
         
         mPinCodeField = (EditText)findViewById(R.id.pin_field);
+        mPinCodeField.setInputType(InputType.TYPE_NULL);
         
         //setup the keyboard
         findViewById(R.id.button0).setOnClickListener(defaultButtonListener);

--- a/library/src/org/wordpress/passcodelock/AbstractPasscodeKeyboardActivity.java
+++ b/library/src/org/wordpress/passcodelock/AbstractPasscodeKeyboardActivity.java
@@ -6,7 +6,6 @@ import android.os.Bundle;
 import android.support.v4.hardware.fingerprint.FingerprintManagerCompat;
 import android.support.v4.os.CancellationSignal;
 import android.text.InputFilter;
-import android.text.InputType;
 import android.text.Spanned;
 import android.view.Gravity;
 import android.view.View;
@@ -52,7 +51,6 @@ public abstract class AbstractPasscodeKeyboardActivity extends Activity {
         filters[1] = onlyNumber;
         
         mPinCodeField = (EditText)findViewById(R.id.pin_field);
-        mPinCodeField.setInputType(InputType.TYPE_NULL);
         
         //setup the keyboard
         findViewById(R.id.button0).setOnClickListener(defaultButtonListener);

--- a/library/src/org/wordpress/passcodelock/AbstractPasscodeKeyboardActivity.java
+++ b/library/src/org/wordpress/passcodelock/AbstractPasscodeKeyboardActivity.java
@@ -6,7 +6,6 @@ import android.os.Bundle;
 import android.support.v4.hardware.fingerprint.FingerprintManagerCompat;
 import android.support.v4.os.CancellationSignal;
 import android.text.InputFilter;
-import android.text.InputType;
 import android.text.Spanned;
 import android.view.Gravity;
 import android.view.View;
@@ -52,8 +51,7 @@ public abstract class AbstractPasscodeKeyboardActivity extends Activity {
         filters[1] = onlyNumber;
         
         mPinCodeField = (EditText)findViewById(R.id.pin_field);
-        mPinCodeField.setInputType(InputType.TYPE_NULL);
-        
+
         //setup the keyboard
         findViewById(R.id.button0).setOnClickListener(defaultButtonListener);
         findViewById(R.id.button1).setOnClickListener(defaultButtonListener);


### PR DESCRIPTION
Fix #30 by setting the input content type of `TYPE_NULL` on the `pin_field` EditText.
I tried different ways of hiding the keyboard, but this was the only way that worked fine.

Note: You have to test this on a real device, since you can't repro the original issue on emulators.

Once this PR is merged, we should publish a new version of the library and update the main wp-android prj.
