### PR TITLE
Add screen shake to incorrect PIN for Manage

### DIFF
--- a/library/src/org/wordpress/passcodelock/PasscodeManagePasswordActivity.java
+++ b/library/src/org/wordpress/passcodelock/PasscodeManagePasswordActivity.java
@@ -47,7 +47,7 @@ public class PasscodeManagePasswordActivity extends AbstractPasscodeKeyboardActi
                     AppLockManager.getInstance().getAppLock().setPassword(null);
                     authenticationSucceeded();
                 } else {
-                    showPasswordError();
+                    authenticationFailed();
                 }
                 break;
             case PasscodePreferenceFragment.ENABLE_PASSLOCK:
@@ -61,7 +61,7 @@ public class PasscodeManagePasswordActivity extends AbstractPasscodeKeyboardActi
                     } else {
                         unverifiedPasscode = null;
                         topMessage.setText(R.string.passcodelock_prompt_message);
-                        showPasswordError();
+                        authenticationFailed();
                     }
                 }
                 break;
@@ -71,7 +71,7 @@ public class PasscodeManagePasswordActivity extends AbstractPasscodeKeyboardActi
                     topMessage.setText(R.string.passcodelock_prompt_message);
                     type = PasscodePreferenceFragment.ENABLE_PASSLOCK;
                 } else {
-                    showPasswordError();
+                    authenticationFailed();
                 } 
                 break;
             default:


### PR DESCRIPTION
#### Fix

Add screen shake while entering an incorrect PIN when performing a Manage operation as described in https://github.com/wordpress-mobile/PasscodeLock-Android/issues/32.
#### Test
1. Set PIN.
2. Go to Manage PIN (Turn Off or Change PIN).
3. Enter incorrect PIN.
#### Review

@daniloercoli
