### PR TITLE
Bump minSdkVersion to 14

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -25,7 +25,7 @@ android {
 
     defaultConfig {
         versionName "1.2.0"
-        minSdkVersion 9
+        minSdkVersion 14
         targetSdkVersion 23
     }
 


### PR DESCRIPTION
Fix #35 - Our `DefaultAppLock` implementation uses APIs from SDK v14 (`ICE_CREAM_SANDWICH`), instead the gradle file in library declares min SDK set to 9.  No need to keep it set to 9.

To test:
`./gradlew :library:lint`
or
`./gradlew :library:build`

Note: It's unlikely that other users of this lib will write their version of AppLock, that's compatible with lower version of SDK. If they do, they have the necessary competencies and can change the minSDK version in gradle.
