### PR TITLE
enabling/disabling fingerprint reader

### DIFF
--- a/library/src/org/wordpress/passcodelock/AbstractAppLock.java
+++ b/library/src/org/wordpress/passcodelock/AbstractAppLock.java
@@ -62,4 +62,8 @@ public abstract class AbstractAppLock implements Application.ActivityLifecycleCa
     public abstract boolean verifyPassword(String password);
     public abstract boolean isPasswordLocked();
     public abstract boolean setPassword(String password);
+    public abstract boolean isFingerprintEnabled();
+    public abstract void enableFingerprint();
+    public abstract void disableFingerprint();
+
 }

--- a/library/src/org/wordpress/passcodelock/DefaultAppLock.java
+++ b/library/src/org/wordpress/passcodelock/DefaultAppLock.java
@@ -92,6 +92,19 @@ public class DefaultAppLock extends AbstractAppLock {
         return true;
     }
 
+    @Override
+    public boolean isFingerprintEnabled() {
+        return mSharedPreferences.getBoolean(BuildConfig.FINGERPRINT_ENABLED, true);
+    }
+
+    public void enableFingerprint() {
+        mSharedPreferences.edit().putBoolean(BuildConfig.FINGERPRINT_ENABLED, true).apply();
+    }
+
+    public void disableFingerprint() {
+        mSharedPreferences.edit().putBoolean(BuildConfig.FINGERPRINT_ENABLED, false).apply();
+    }
+
     public void forcePasswordLock() {
         mLostFocusDate = null;
     }

--- a/library/src/org/wordpress/passcodelock/PasscodeUnlockActivity.java
+++ b/library/src/org/wordpress/passcodelock/PasscodeUnlockActivity.java
@@ -10,7 +10,7 @@ public class PasscodeUnlockActivity extends AbstractPasscodeKeyboardActivity {
     public void onResume() {
         super.onResume();
 
-        if (isFingerprintSupported()) {
+        if (isFingerprintSupportedAndEnabled()) {
             mCancel = new CancellationSignal();
             mFingerprintManager.authenticate(null, 0, mCancel, getFingerprintCallback(), null);
             View view = findViewById(R.id.image_fingerprint);
@@ -58,8 +58,12 @@ public class PasscodeUnlockActivity extends AbstractPasscodeKeyboardActivity {
         };
     }
 
-    private boolean isFingerprintSupported() {
+    private boolean isFingerprintSupportedAndEnabled() {
         return mFingerprintManager.isHardwareDetected() &&
-               mFingerprintManager.hasEnrolledFingerprints();
+               mFingerprintManager.hasEnrolledFingerprints() &&
+               getAppLock().isFingerprintEnabled();
+
+
+
     }
 }


### PR DESCRIPTION
I have added some functionality for enabling and disabling the fingerprint reader. We have a case in one of our apps where somebody else than the user himself sets a PIN, but the user himself can unlock using his fingerprint. Hence, we disabled the fingerprint reader.
