### PR TITLE
Release version 1.5

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -27,7 +27,7 @@ android {
     buildToolsVersion "25.0.0"
 
     defaultConfig {
-        versionName "1.4.0"
+        versionName "1.5.0"
         minSdkVersion 14
         targetSdkVersion 25
     }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.1'
+        classpath 'com.android.tools.build:gradle:2.2.2'
         classpath 'com.novoda:bintray-release:0.3.4'
     }
 }
@@ -24,7 +24,7 @@ dependencies {
 android {
     publishNonDefault true
     compileSdkVersion 25
-    buildToolsVersion "24.0.3"
+    buildToolsVersion "25.0.0"
 
     defaultConfig {
         versionName "1.4.0"

--- a/library/res/values/styles.xml
+++ b/library/res/values/styles.xml
@@ -13,7 +13,7 @@
         <item name="android:textColor">@color/passcodelock_button_text_color</item>
         <item name="android:textSize">@dimen/passcodelock_button_text_size</item>
         <item name="android:clickable">true</item>
-        <item name="android:background">?android:attr/selectableItemBackground</item>
+        <item name="android:background">?attr/selectableItemBackground</item>
    </style>
 
     <style name="PasscodeEditTextStyle">

--- a/library/src/org/wordpress/passcodelock/PasscodePreferenceFragment.java
+++ b/library/src/org/wordpress/passcodelock/PasscodePreferenceFragment.java
@@ -35,9 +35,7 @@ public class PasscodePreferenceFragment extends PreferenceFragment
     public boolean onPreferenceClick(Preference preference) {
         String preferenceKey = preference.getKey() != null ? preference.getKey() : "";
 
-        if (preferenceKey.equals(getString(R.string.pref_key_passcode_toggle))) {
-            return handlePasscodeToggleClick();
-        } else if (preferenceKey.equals(getString(R.string.pref_key_change_passcode))) {
+       if (preferenceKey.equals(getString(R.string.pref_key_change_passcode))) {
             return handleChangePasscodeClick();
         }
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "24.0.3"
+    buildToolsVersion "25.0.0"
 
     buildTypes {
         release {
@@ -22,7 +22,7 @@ android {
 
 buildscript {
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.1'
+        classpath 'com.android.tools.build:gradle:2.2.2'
     }
 
     repositories {

--- a/sample/src/main/res/values/styles.xml
+++ b/sample/src/main/res/values/styles.xml
@@ -18,7 +18,7 @@
     </style>
 
     <style name="PasscodeKeyboardButtonStyle" parent="@android:style/Widget.Button">
-        <item name="android:background">?android:attr/selectableItemBackgroundBorderless</item>
+        <item name="android:background">?attr/selectableItemBackgroundBorderless</item>
         <item name="android:clickable">true</item>
         <item name="android:textColor">@color/white</item>
         <item name="android:textSize">@dimen/passcodelock_button_text_size</item>


### PR DESCRIPTION
I think we should release a new version of the library, since we've fixed the issues with Pre-Lollipop devices, and added the ability of disabling Fingerprint.

Chaining this PR to https://github.com/wordpress-mobile/PasscodeLock-Android/pull/48. So wait until #48 is merged.

cc @roundhill 
