### PR TITLE
[Facepalm] PIN input screen can be easily bypassed

### DIFF
--- a/library/src/org/wordpress/passcodelock/DefaultAppLock.java
+++ b/library/src/org/wordpress/passcodelock/DefaultAppLock.java
@@ -39,7 +39,7 @@ public class DefaultAppLock extends AbstractAppLock {
     /** {@link PasscodeUnlockActivity} is always exempt. */
     @Override
     public boolean isExemptActivity(String activityName) {
-        return !UNLOCK_CLASS_NAME.equals(activityName) && super.isExemptActivity(activityName);
+        return UNLOCK_CLASS_NAME.equals(activityName) || super.isExemptActivity(activityName);
     }
 
     @Override


### PR DESCRIPTION
Fix #42

I think the issue was introduced in the big refactor of the library almost 2 years ago. It wasn't there in the first version of the library.

cc @theck13 