### PR TITLE
Release 1.5.1

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -27,7 +27,7 @@ android {
     buildToolsVersion "25.0.0"
 
     defaultConfig {
-        versionName "1.5.0"
+        versionName "1.5.1"
         minSdkVersion 14
         targetSdkVersion 25
     }

--- a/library/src/org/wordpress/passcodelock/DefaultAppLock.java
+++ b/library/src/org/wordpress/passcodelock/DefaultAppLock.java
@@ -39,7 +39,7 @@ public class DefaultAppLock extends AbstractAppLock {
     /** {@link PasscodeUnlockActivity} is always exempt. */
     @Override
     public boolean isExemptActivity(String activityName) {
-        return !UNLOCK_CLASS_NAME.equals(activityName) && super.isExemptActivity(activityName);
+        return UNLOCK_CLASS_NAME.equals(activityName) || super.isExemptActivity(activityName);
     }
 
     @Override


### PR DESCRIPTION
We should release a new library version asap, since the bug fixed here https://github.com/wordpress-mobile/PasscodeLock-Android/pull/50 is terrible.

Note: Branched on the top of the branch ^^ . 