### PR TITLE
Add Haptic Feedback

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -27,7 +27,7 @@ android {
     buildToolsVersion "25.0.0"
 
     defaultConfig {
-        versionName "1.5.1"
+        versionName "1.6.0"
         minSdkVersion 14
         targetSdkVersion 25
     }

--- a/library/src/org/wordpress/passcodelock/AbstractPasscodeKeyboardActivity.java
+++ b/library/src/org/wordpress/passcodelock/AbstractPasscodeKeyboardActivity.java
@@ -8,6 +8,7 @@ import android.support.v4.os.CancellationSignal;
 import android.text.InputFilter;
 import android.text.Spanned;
 import android.view.Gravity;
+import android.view.HapticFeedbackConstants;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.animation.Animation;
@@ -118,6 +119,10 @@ public abstract class AbstractPasscodeKeyboardActivity extends Activity {
 			} else if (id == R.id.button9) {
 				currentValue = 9;
 			}
+
+            if (arg0.isHapticFeedbackEnabled()) {
+                arg0.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP);
+            }
 
             //set the value and move the focus
             String currentValueString = mPinCodeField.getText() + String.valueOf(currentValue);

--- a/library/src/org/wordpress/passcodelock/AbstractPasscodeKeyboardActivity.java
+++ b/library/src/org/wordpress/passcodelock/AbstractPasscodeKeyboardActivity.java
@@ -68,6 +68,10 @@ public abstract class AbstractPasscodeKeyboardActivity extends Activity {
                 new OnClickListener() {
                     @Override
                     public void onClick(View arg0) {
+                        if (arg0.isHapticFeedbackEnabled()) {
+                            arg0.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP);
+                        }
+
                         String curText = mPinCodeField.getText().toString();
 
                         if (curText.length() > 0) {


### PR DESCRIPTION
### Fix
Add haptic feedback when tapping passcode buttons to mimic the Android operating system behavior as requested in https://github.com/Automattic/simplenote-android/pull/705#issuecomment-503650825.

### Test
#### Passcode Lock Disabled
1. Launch sample app.
2. Tap ***Settings*** action.
3. Tap ***Enable lock*** item.
4. Tap any passcode button.
5. Notice haptic feedback.

#### Passcode Lock Enabled
1. Launch sample app.
2. Tap any passcode button.
3. Notice haptic feedback.

### Review
Only one developer is required to review these changes, but anyone can perform the review.