### PR TITLE
Update Android X

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,3 @@
+repositories {
+    google()
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri May 27 12:41:28 MDT 2016
+#Mon Jul 22 9:08:50 MDT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip

--- a/library/AndroidManifest.xml
+++ b/library/AndroidManifest.xml
@@ -3,8 +3,7 @@
 <manifest
     xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.wordpress.passcodelock"
-    android:versionCode="1"
-    android:versionName="0.0.5" >
+    android:versionCode="1" >
 
     <uses-permission
         android:name="android.permission.USE_FINGERPRINT" />

--- a/library/AndroidManifest.xml
+++ b/library/AndroidManifest.xml
@@ -9,10 +9,6 @@
     <uses-permission
         android:name="android.permission.USE_FINGERPRINT" />
 
-    <uses-sdk
-        android:minSdkVersion="14"
-        android:targetSdkVersion="23" />
-
 <!-- Define the following activities in your project 
     <activity
         android:name="org.wordpress.passcodelock.PasscodeUnlockActivity"

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -22,7 +22,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'androidx.appcompat:appcompat:1.0.0'
+    implementation 'androidx.appcompat:appcompat:1.0.2'
     implementation 'androidx.preference:preference:1.0.0'
 }
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,10 +1,13 @@
 buildscript {
-    repositories {
-        jcenter()
-    }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.2'
-        classpath 'com.novoda:bintray-release:0.3.4'
+        classpath 'com.android.tools.build:gradle:3.4.2'
+        classpath 'com.novoda:bintray-release:0.8.1'
+    }
+
+    repositories {
+        google()
+        jcenter()
+        maven { url 'https://maven.google.com' }
     }
 }
 
@@ -13,18 +16,20 @@ apply plugin: 'maven'
 apply plugin: 'com.novoda.bintray-release'
 
 repositories {
+    google()
     jcenter()
+    maven { url 'https://maven.google.com' }
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:25.0.0'
-    compile 'com.android.support:preference-v7:25.0.0'
+    implementation 'com.android.support:appcompat-v7:28.0.0'
+    implementation 'com.android.support:preference-v7:28.0.0'
 }
 
 android {
     publishNonDefault true
     compileSdkVersion 28
-    buildToolsVersion "25.0.0"
+    buildToolsVersion "28.0.3"
 
     defaultConfig {
         versionName "1.6.0"
@@ -58,7 +63,7 @@ publish {
     groupId = 'org.wordpress'
     uploadName = 'passcodelock'
     artifactId = 'passcodelock'
-    description = ' Android Library that provides passcode lock to your app'
+    desc = 'Android library that provides passcode lock to your app'
     publishVersion = android.defaultConfig.versionName
     licences = ['MIT', 'GPL-2.0']
     website = 'https://github.com/wordpress-mobile/PasscodeLock-Android'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -22,8 +22,8 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.android.support:appcompat-v7:28.0.0'
-    implementation 'com.android.support:preference-v7:28.0.0'
+    implementation 'androidx.appcompat:appcompat:1.0.0'
+    implementation 'androidx.preference:preference:1.0.0'
 }
 
 android {

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -23,13 +23,13 @@ dependencies {
 
 android {
     publishNonDefault true
-    compileSdkVersion 25
+    compileSdkVersion 28
     buildToolsVersion "25.0.0"
 
     defaultConfig {
         versionName "1.6.0"
         minSdkVersion 14
-        targetSdkVersion 25
+        targetSdkVersion 28
     }
 
     sourceSets {

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -32,7 +32,7 @@ android {
     buildToolsVersion "28.0.3"
 
     defaultConfig {
-        versionName "1.6.0"
+        versionName "1.7.0"
         minSdkVersion 14
         targetSdkVersion 28
     }

--- a/library/gradle.properties-example
+++ b/library/gradle.properties-example
@@ -1,3 +1,6 @@
+android.enableJetifier=true
+android.useAndroidX=true
+
 passcodelock.password_preference_key=passcode_lock_prefs_password_key
 passcodelock.password_enc_secret=5-maggio-2002-Karel-Poborsky
 passcodelock.fingerprint_enabled_key=passcode_lock_prefs_fingerprint_enabled_key

--- a/library/src/org/wordpress/passcodelock/AbstractPasscodeKeyboardActivity.java
+++ b/library/src/org/wordpress/passcodelock/AbstractPasscodeKeyboardActivity.java
@@ -3,8 +3,6 @@ package org.wordpress.passcodelock;
 import android.app.Activity;
 import android.content.pm.ActivityInfo;
 import android.os.Bundle;
-import android.support.v4.hardware.fingerprint.FingerprintManagerCompat;
-import android.support.v4.os.CancellationSignal;
 import android.text.InputFilter;
 import android.text.Spanned;
 import android.view.Gravity;
@@ -16,6 +14,9 @@ import android.view.animation.AnimationUtils;
 import android.widget.EditText;
 import android.widget.TextView;
 import android.widget.Toast;
+
+import androidx.core.hardware.fingerprint.FingerprintManagerCompat;
+import androidx.core.os.CancellationSignal;
 
 public abstract class AbstractPasscodeKeyboardActivity extends Activity {
     public static final String KEY_MESSAGE = "message";

--- a/library/src/org/wordpress/passcodelock/PasscodeManagePasswordActivity.java
+++ b/library/src/org/wordpress/passcodelock/PasscodeManagePasswordActivity.java
@@ -1,10 +1,11 @@
 package org.wordpress.passcodelock;
 
 import android.os.Bundle;
-import android.support.v4.hardware.fingerprint.FingerprintManagerCompat;
-import android.support.v4.os.CancellationSignal;
 import android.view.View;
 import android.widget.TextView;
+
+import androidx.core.hardware.fingerprint.FingerprintManagerCompat;
+import androidx.core.os.CancellationSignal;
 
 public class PasscodeManagePasswordActivity extends AbstractPasscodeKeyboardActivity {
     public static final String  KEY_TYPE = "type";

--- a/library/src/org/wordpress/passcodelock/PasscodePreferenceFragmentCompat.java
+++ b/library/src/org/wordpress/passcodelock/PasscodePreferenceFragmentCompat.java
@@ -2,8 +2,9 @@ package org.wordpress.passcodelock;
 
 import android.content.Intent;
 import android.os.Bundle;
-import android.support.v7.preference.Preference;
-import android.support.v7.preference.PreferenceFragmentCompat;
+
+import androidx.preference.Preference;
+import androidx.preference.PreferenceFragmentCompat;
 
 public class PasscodePreferenceFragmentCompat extends PreferenceFragmentCompat
         implements Preference.OnPreferenceClickListener {

--- a/library/src/org/wordpress/passcodelock/PasscodeUnlockActivity.java
+++ b/library/src/org/wordpress/passcodelock/PasscodeUnlockActivity.java
@@ -1,9 +1,10 @@
 package org.wordpress.passcodelock;
 
 import android.content.Intent;
-import android.support.v4.hardware.fingerprint.FingerprintManagerCompat;
-import android.support.v4.os.CancellationSignal;
 import android.view.View;
+
+import androidx.core.hardware.fingerprint.FingerprintManagerCompat;
+import androidx.core.os.CancellationSignal;
 
 public class PasscodeUnlockActivity extends AbstractPasscodeKeyboardActivity {
     @Override

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -33,7 +33,7 @@ buildscript {
 }
 
 dependencies {
-    implementation 'androidx.appcompat:appcompat:1.0.0'
+    implementation 'androidx.appcompat:appcompat:1.0.2'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation project(path: ':library')
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 28
-    buildToolsVersion "25.0.0"
+    buildToolsVersion "28.0.3"
 
     buildTypes {
         release {
@@ -22,20 +22,23 @@ android {
 
 buildscript {
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.2'
+        classpath 'com.android.tools.build:gradle:3.4.2'
     }
 
     repositories {
+        google()
         jcenter()
+        maven { url 'https://maven.google.com' }
     }
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:25.0.0'
-    compile 'com.android.support:support-v4:25.0.0'
-    compile project(path: ':library')
+    implementation 'com.android.support:appcompat-v7:28.0.0'
+    implementation 'com.android.support:support-v4:28.0.0'
+    implementation project(path: ':library')
 }
 
 repositories {
+    google()
     mavenCentral()
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -33,8 +33,8 @@ buildscript {
 }
 
 dependencies {
-    implementation 'com.android.support:appcompat-v7:28.0.0'
-    implementation 'com.android.support:support-v4:28.0.0'
+    implementation 'androidx.appcompat:appcompat:1.0.0'
+    implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation project(path: ':library')
 }
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
+    compileSdkVersion 28
     buildToolsVersion "25.0.0"
 
     buildTypes {
@@ -14,7 +14,7 @@ android {
     defaultConfig {
         applicationId "org.wordpress.passcodelock.sample"
         minSdkVersion 14
-        targetSdkVersion 25
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
     }

--- a/sample/src/main/java/org/wordpress/passcodelock/sample/SampleActivity.java
+++ b/sample/src/main/java/org/wordpress/passcodelock/sample/SampleActivity.java
@@ -2,10 +2,11 @@ package org.wordpress.passcodelock.sample;
 
 import android.content.Intent;
 import android.os.Bundle;
-import android.support.v7.app.AppCompatActivity;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
+
+import androidx.appcompat.app.AppCompatActivity;
 
 public class SampleActivity extends AppCompatActivity {
     @Override

--- a/sample/src/main/java/org/wordpress/passcodelock/sample/SamplePreferenceActivity.java
+++ b/sample/src/main/java/org/wordpress/passcodelock/sample/SamplePreferenceActivity.java
@@ -4,9 +4,10 @@ import android.app.FragmentManager;
 import android.os.Bundle;
 import android.preference.Preference;
 import android.preference.SwitchPreference;
-import android.support.v7.app.ActionBar;
-import android.support.v7.app.AppCompatActivity;
 import android.view.MenuItem;
+
+import androidx.appcompat.app.ActionBar;
+import androidx.appcompat.app.AppCompatActivity;
 
 import org.wordpress.passcodelock.AppLockManager;
 import org.wordpress.passcodelock.PasscodePreferenceFragment;


### PR DESCRIPTION
### Fix
Update the Android support library from `com.android.support` to `androidx`.  This is a prerequisite for the login/signup changes to Simplenote in https://github.com/Automattic/simplenote-android/pull/756.

### Test
#### Passcode Lock Disabled
1. Launch sample app.
2. Tap ***Settings*** action.
3. Tap ***Enable lock*** item.
4. Enter passcode.
5. Enter passcode again.
6. Notice app works as expected.

#### Passcode Lock Enabled
1. Launch sample app.
2. Enter passcode.
3. Notice app works as expected.

### Review
Only one developer is required to review these changes, but anyone can perform the review.