### PR TITLE
Update Bintray 0.9.1

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:3.4.2'
-        classpath 'com.novoda:bintray-release:0.8.1'
+        classpath 'com.novoda:bintray-release:0.9.1'
     }
 
     repositories {


### PR DESCRIPTION
### Fix
Update the `com.novoda:bintray-release` dependency from `0.8.1` to `0.9.1`.  Running the publishing command with `0.8.1` results in the follow error.

```
FAILURE: Build failed with an exception.

* What went wrong:
java.lang.AbstractMethodError (no error message)
```

That error is related to https://github.com/novoda/bintray-release/issues/177 and fixed in `0.9` with https://github.com/novoda/bintray-release/pull/250.

### Test
Run the following command after replace `USER` and `KEY` with your BIntray user and key to verify the build succeeds.
```
./gradlew publishToMavenLocal bintrayUpload -PbintrayUser=USER -PbintrayKey=KEY -PdryRun=true
```

### Review
Only one developer is required to review these changes, but anyone can perform the review.