### PR TITLE
Update Keypad Layout

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -34,8 +34,8 @@ android {
     defaultConfig {
         minSdkVersion 14
         targetSdkVersion 28
-        versionCode 2
-        versionName "2.0.0"
+        versionCode 3
+        versionName "2.0.1"
     }
 
     sourceSets {

--- a/library/res/layout/app_passcode_keyboard.xml
+++ b/library/res/layout/app_passcode_keyboard.xml
@@ -27,6 +27,7 @@
 
     <RelativeLayout
         android:id="@+id/AppUnlockLinearLayout1"
+        android:gravity="center"
         android:layout_below="@id/passcodelock_prompt"
         android:layout_height="match_parent"
         android:layout_width="match_parent">
@@ -60,7 +61,6 @@
 
         <TableLayout
             android:id="@+id/tableLayout1"
-            android:layout_centerVertical="true"
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"
             android:layout_width="match_parent"

--- a/library/res/layout/app_passcode_keyboard.xml
+++ b/library/res/layout/app_passcode_keyboard.xml
@@ -3,7 +3,6 @@
 <RelativeLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/AppUnlockLinearLayout1"
     android:background="@color/passcodelock_background"
     android:layout_height="match_parent"
     android:layout_width="match_parent"
@@ -26,141 +25,149 @@
         android:textSize="20sp">
     </TextView>
 
-    <EditText
-        android:id="@+id/pin_field"
-        android:clickable="false"
-        android:focusable="false"
-        android:gravity="center"
-        android:hint="@string/passcodelock_hint"
-        android:importantForAutofill="no"
-        android:inputType="numberPassword"
-        android:layout_above="@id/divider"
-        android:layout_height="wrap_content"
-        android:layout_width="match_parent"
-        android:letterSpacing="0.3"
-        android:maxLength="4"
-        tools:targetApi="lollipop"
-        style="@style/PasscodeEditTextStyle">
-    </EditText>
-
-    <View
-        android:id="@+id/divider"
-        android:background="@color/passcodelock_divider"
-        android:layout_above="@id/tableLayout1"
-        android:layout_height="@dimen/passcodelock_divider"
-        android:layout_marginLeft="16dp"
-        android:layout_marginRight="16dp"
+    <RelativeLayout
+        android:id="@+id/AppUnlockLinearLayout1"
+        android:layout_below="@id/passcodelock_prompt"
+        android:layout_height="match_parent"
         android:layout_width="match_parent">
-    </View>
 
-    <TableLayout
-        android:id="@+id/tableLayout1"
-        android:layout_alignParentBottom="true"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
-        android:layout_width="match_parent"
-        android:shrinkColumns="*"
-        android:stretchColumns="*">
+        <EditText
+            android:id="@+id/pin_field"
+            android:clickable="false"
+            android:focusable="false"
+            android:gravity="center"
+            android:hint="@string/passcodelock_hint"
+            android:importantForAutofill="no"
+            android:inputType="numberPassword"
+            android:layout_above="@id/divider"
+            android:layout_height="wrap_content"
+            android:layout_width="match_parent"
+            android:letterSpacing="0.3"
+            android:maxLength="4"
+            tools:targetApi="lollipop"
+            style="@style/PasscodeEditTextStyle">
+        </EditText>
 
-        <TableRow>
+        <View
+            android:id="@+id/divider"
+            android:background="@color/passcodelock_divider"
+            android:layout_above="@id/tableLayout1"
+            android:layout_height="@dimen/passcodelock_divider"
+            android:layout_marginLeft="16dp"
+            android:layout_marginRight="16dp"
+            android:layout_width="match_parent">
+        </View>
 
-            <Button
-                android:id="@+id/button1"
-                android:text="@string/passcodelock_numpad_1"
-                style="@style/PasscodeKeyboardButtonStyle">
-            </Button>
+        <TableLayout
+            android:id="@+id/tableLayout1"
+            android:layout_centerVertical="true"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:layout_width="match_parent"
+            android:shrinkColumns="*"
+            android:stretchColumns="*">
 
-            <Button
-                android:id="@+id/button2"
-                android:text="@string/passcodelock_numpad_2"
-                style="@style/PasscodeKeyboardButtonStyle">
-            </Button>
+            <TableRow>
 
-            <Button
-                android:id="@+id/button3"
-                android:text="@string/passcodelock_numpad_3"
-                style="@style/PasscodeKeyboardButtonStyle">
-            </Button>
+                <Button
+                    android:id="@+id/button1"
+                    android:text="@string/passcodelock_numpad_1"
+                    style="@style/PasscodeKeyboardButtonStyle">
+                </Button>
 
-        </TableRow>
+                <Button
+                    android:id="@+id/button2"
+                    android:text="@string/passcodelock_numpad_2"
+                    style="@style/PasscodeKeyboardButtonStyle">
+                </Button>
 
-        <TableRow>
+                <Button
+                    android:id="@+id/button3"
+                    android:text="@string/passcodelock_numpad_3"
+                    style="@style/PasscodeKeyboardButtonStyle">
+                </Button>
 
-            <Button
-                android:id="@+id/button4"
-                android:text="@string/passcodelock_numpad_4"
-                style="@style/PasscodeKeyboardButtonStyle">
-            </Button>
+            </TableRow>
 
-            <Button
-                android:id="@+id/button5"
-                android:text="@string/passcodelock_numpad_5"
-                style="@style/PasscodeKeyboardButtonStyle">
-            </Button>
+            <TableRow>
 
-            <Button
-                android:id="@+id/button6"
-                android:text="@string/passcodelock_numpad_6"
-                style="@style/PasscodeKeyboardButtonStyle">
-            </Button>
+                <Button
+                    android:id="@+id/button4"
+                    android:text="@string/passcodelock_numpad_4"
+                    style="@style/PasscodeKeyboardButtonStyle">
+                </Button>
 
-        </TableRow>
+                <Button
+                    android:id="@+id/button5"
+                    android:text="@string/passcodelock_numpad_5"
+                    style="@style/PasscodeKeyboardButtonStyle">
+                </Button>
 
-        <TableRow>
+                <Button
+                    android:id="@+id/button6"
+                    android:text="@string/passcodelock_numpad_6"
+                    style="@style/PasscodeKeyboardButtonStyle">
+                </Button>
 
-            <Button
-                android:id="@+id/button7"
-                android:text="@string/passcodelock_numpad_7"
-                style="@style/PasscodeKeyboardButtonStyle">
-            </Button>
+            </TableRow>
 
-            <Button
-                android:id="@+id/button8"
-                android:text="@string/passcodelock_numpad_8"
-                style="@style/PasscodeKeyboardButtonStyle">
-            </Button>
+            <TableRow>
 
-            <Button
-                android:id="@+id/button9"
-                android:text="@string/passcodelock_numpad_9"
-                style="@style/PasscodeKeyboardButtonStyle">
-            </Button>
+                <Button
+                    android:id="@+id/button7"
+                    android:text="@string/passcodelock_numpad_7"
+                    style="@style/PasscodeKeyboardButtonStyle">
+                </Button>
 
-        </TableRow>
+                <Button
+                    android:id="@+id/button8"
+                    android:text="@string/passcodelock_numpad_8"
+                    style="@style/PasscodeKeyboardButtonStyle">
+                </Button>
 
-        <TableRow>
+                <Button
+                    android:id="@+id/button9"
+                    android:text="@string/passcodelock_numpad_9"
+                    style="@style/PasscodeKeyboardButtonStyle">
+                </Button>
 
-            <ImageButton
-                android:id="@+id/image_fingerprint"
-                android:clickable="false"
-                android:contentDescription="@string/passcode_description_fingerprint"
-                android:focusable="false"
-                android:layout_height="fill_parent"
-                android:layout_width="fill_parent"
-                android:scaleType="centerInside"
-                android:src="@drawable/ic_fingerprint_white_24dp"
-                android:visibility="invisible"
-                style="@style/PasscodeKeyboardImageStyle">
-            </ImageButton>
+            </TableRow>
 
-            <Button
-                android:id="@+id/button0"
-                android:text="@string/passcodelock_numpad_0"
-                style="@style/PasscodeKeyboardButtonStyle">
-            </Button>
+            <TableRow>
 
-            <ImageButton
-                android:id="@+id/button_erase"
-                android:contentDescription="@string/passcode_description_delete"
-                android:layout_height="fill_parent"
-                android:layout_width="fill_parent"
-                android:scaleType="centerInside"
-                android:src="@drawable/ic_backspace_white_24dp"
-                style="@style/PasscodeKeyboardImageStyle">
-            </ImageButton>
+                <ImageButton
+                    android:id="@+id/image_fingerprint"
+                    android:clickable="false"
+                    android:contentDescription="@string/passcode_description_fingerprint"
+                    android:focusable="false"
+                    android:layout_height="fill_parent"
+                    android:layout_width="fill_parent"
+                    android:scaleType="centerInside"
+                    android:src="@drawable/ic_fingerprint_white_24dp"
+                    android:visibility="invisible"
+                    style="@style/PasscodeKeyboardImageStyle">
+                </ImageButton>
 
-        </TableRow>
+                <Button
+                    android:id="@+id/button0"
+                    android:text="@string/passcodelock_numpad_0"
+                    style="@style/PasscodeKeyboardButtonStyle">
+                </Button>
 
-    </TableLayout>
+                <ImageButton
+                    android:id="@+id/button_erase"
+                    android:contentDescription="@string/passcode_description_delete"
+                    android:layout_height="fill_parent"
+                    android:layout_width="fill_parent"
+                    android:scaleType="centerInside"
+                    android:src="@drawable/ic_backspace_white_24dp"
+                    style="@style/PasscodeKeyboardImageStyle">
+                </ImageButton>
+
+            </TableRow>
+
+        </TableLayout>
+
+    </RelativeLayout>
 
 </RelativeLayout>


### PR DESCRIPTION
### Fix
Update the numeric keypad in the passcode layout to be centered so that devices with in-display/in-screen fingerprint sensors do not overlap the numeric keypad.  Note that these changes only affect the layout of the library.  See the screenshots below for illustration.

![passcode_lock_center](https://user-images.githubusercontent.com/3827611/72912713-462b7d80-3cf9-11ea-8439-44fe6f773177.png)

### Test
The fingerprint icon shown below the number 7 is only visible if the device has fingerprint authentication hardware.  If the device does not have that hardware, the icon is not shown.  For devices with in-display/in-screen fingerprint sensors, the device-specific fingerprint authentication indicator will be show below the numeric keypad.
1. Launch sample app.
2. Tap ***Settings*** action.
3. Tap ***Enable lock*** item.
4. Enter passcode.
5. Enter passcode again.
6. Notice app layout is as screenshots shown above.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

#### Note
Using the ***Hide whitespace changes*** setting on the ***Files changed*** tab will make reviewing the changes easier in GitHub.