### PR TITLE
Update Passcode Divider

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -34,8 +34,8 @@ android {
     defaultConfig {
         minSdkVersion 14
         targetSdkVersion 28
-        versionCode 3
-        versionName "2.0.1"
+        versionCode 4
+        versionName "2.0.2"
     }
 
     sourceSets {

--- a/library/res/layout/app_passcode_keyboard.xml
+++ b/library/res/layout/app_passcode_keyboard.xml
@@ -25,12 +25,13 @@
         android:textSize="20sp">
     </TextView>
 
-    <RelativeLayout
+    <LinearLayout
         android:id="@+id/AppUnlockLinearLayout1"
         android:gravity="center"
         android:layout_below="@id/passcodelock_prompt"
         android:layout_height="match_parent"
-        android:layout_width="match_parent">
+        android:layout_width="match_parent"
+        android:orientation="vertical">
 
         <EditText
             android:id="@+id/pin_field"
@@ -40,7 +41,6 @@
             android:hint="@string/passcodelock_hint"
             android:importantForAutofill="no"
             android:inputType="numberPassword"
-            android:layout_above="@id/divider"
             android:layout_height="wrap_content"
             android:layout_width="match_parent"
             android:letterSpacing="0.3"
@@ -52,7 +52,6 @@
         <View
             android:id="@+id/divider"
             android:background="@color/passcodelock_divider"
-            android:layout_above="@id/tableLayout1"
             android:layout_height="@dimen/passcodelock_divider"
             android:layout_marginLeft="16dp"
             android:layout_marginRight="16dp"
@@ -168,6 +167,6 @@
 
         </TableLayout>
 
-    </RelativeLayout>
+    </LinearLayout>
 
 </RelativeLayout>


### PR DESCRIPTION
### Fix
Update the numeric keypad parent view of the passcode layout from `RelativeLayout` to `LinearLayout` so that the divider between the numeric keypad and the prompt is shown.  Note that these changes only affect the layout of the library.  See the screenshots below for illustration.

![update_passcode_divider](https://user-images.githubusercontent.com/3827611/73371071-65368c00-4272-11ea-8a1d-b90d9aecf55f.png)

### Test
1. Launch sample app.
2. Tap ***Settings*** action.
3. Tap ***Enable lock*** item.
4. Enter passcode.
5. Enter passcode again.
6. Notice app layout is as screenshots shown above.

### Review
Only one developer is required to review these changes, but anyone can perform the review.